### PR TITLE
Adding afterClick option to LaunchLink to allow for parent element to…

### DIFF
--- a/app/js/components/LaunchLink.jsx
+++ b/app/js/components/LaunchLink.jsx
@@ -32,7 +32,11 @@ var LaunchLink = React.createClass({
         newTab: React.PropTypes.oneOfType([
             React.PropTypes.bool,
             React.PropTypes.object
-        ])
+        ]),
+
+        // Callback called on click, passing information about whether a WebtopLaunchLink or TabLaunchLink
+        // was created
+        afterClick: React.PropTypes.func
     },
 
     getInitialState: function() {
@@ -45,7 +49,7 @@ var LaunchLink = React.createClass({
 
     render: function() {
         var launchInWebtop = this.state.launchInWebtop,
-            { children, newTab, ...otherProps } = this.props,
+            { children, newTab, afterClick, ...otherProps } = this.props,
             Component,
             openInNewTab;
 
@@ -59,7 +63,11 @@ var LaunchLink = React.createClass({
         }
 
         return (
-            <Component newTab={openInNewTab} {...otherProps}>
+            <Component newTab={openInNewTab} {...otherProps} onClick={()=>{
+                if(afterClick !== undefined) {
+                    afterClick(launchInWebtop);
+                }
+            }}>
                 {children}
             </Component>
         );


### PR DESCRIPTION
… determine if launched in webtop

This change is necessary to allow for HUD to report different metrics based on whether or not the link is launched in webtop or in a new tab. That state is determined by the underlying component, so I created a callback that will be passed the state of whether or not it is launched in webtop.