### PR TITLE
fix(unit tests): Update reporting; fix failing launch webtop test.

### DIFF
--- a/app/js/components/__tests__/WebtopLaunchLink-test.js
+++ b/app/js/components/__tests__/WebtopLaunchLink-test.js
@@ -10,7 +10,7 @@ describe('WebtopLaunchLink', function() {
     var webtopLaunchLinkFactory = require('inject?../OzoneConfig!../WebtopLaunchLink.jsx'),
         WebtopLaunchLink = webtopLaunchLinkFactory({
             '../OzoneConfig': {
-                WEBTOP_URL: 'https://widgethome/webtop/'
+                WEBTOP_URL: 'https://widgethome/webtop'
             }
         });
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -60,9 +60,17 @@ module.exports = function (config) {
         // - PhantomJS
         // - IE (only Windows)
         browsers: ['PhantomJS'],
-        reporters: ['progress'],
+        reporters: ['mocha'],
         captureTimeout: 60000,
         browserNoActivityTimeout: 60000,
-        singleRun: true
+        singleRun: true,
+        plugins: [
+            'karma-jasmine',
+            'karma-mocha-reporter',
+            'karma-phantomjs-launcher',
+            'karma-webpack',
+            'karma-mocha'
+        ]
+
     });
 };

--- a/package.json
+++ b/package.json
@@ -30,10 +30,13 @@
     "chai": "1.10.0",
     "fs": "0.0.2",
     "inject-loader": "1.0.0",
+    "jasmine-core": "^2.3.4",
     "jsx-loader": "0.12.2",
     "jsxhint-loader": "0.2.0",
     "karma": "0.12.31",
+    "karma-jasmine": "^0.3.6",
     "karma-mocha": "0.1.10",
+    "karma-mocha-reporter": "^1.0.2",
     "karma-phantomjs-launcher": "0.1.4",
     "karma-webpack": "1.3.1",
     "sinon": "1.7.0"


### PR DESCRIPTION
1. Update unit test reporting to look like Center's unit test reporting - mocha style red/green x/checkmarks. 
2. Remove trailing slash from webtop launch URL test.